### PR TITLE
Update usage instructions for EOSTransport

### DIFF
--- a/systems-and-modules/transports/eos-transport.md
+++ b/systems-and-modules/transports/eos-transport.md
@@ -38,9 +38,11 @@ Then set up your Epic dev account and product credentials under **Tools / EOS Pl
 
 1. Add the `EOSTransport` component to your `NetworkManager`.
 2. Set `socketName` to any string. Both peers just need to agree on it.
-3. On the client, set `remoteProductUserId` to the host's EOS Product User ID before connecting.
+3. On the client, set `remoteProductUserId` to the **host's** EOS Product User ID before connecting.
 4. Call `NetworkManager.StartServer()` to host, `NetworkManager.StartClient()` to join.
 
 If you call `StartClient()` on the same `NetworkManager` that's already hosting, it short-circuits to in-process delivery instead of going through EOS. Host loopback, no extra wiring.
+
+*If you're testing with multiple unity projects and running into connection issues make sure to focus the server window after connecting a client or it will fail due to inactivity.* 
 
 {% embed url="https://github.com/PurrNet/PurrNetEOSTransport" %}


### PR DESCRIPTION
Emphasize the importance of setting remoteProductUserId correctly and add a note about connection issues when testing with multiple Unity projects.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/PurrNet/codesmith/PurrDocs/pr/26"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782132411&installation_id=129033668&pr_number=26&repository=PurrNet%2FPurrDocs&return_to=https%3A%2F%2Fgithub.com%2FPurrNet%2FPurrDocs%2Fpull%2F26&signature=96c0520f8d3e73875021b9d24530a7c68148d32c6c0406bea804a77ae5ee41af"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified EOS Transport setup instructions with explicit step ordering for client configuration.
  * Added testing guidance regarding server window focus requirements when running multiple projects to prevent connection failures.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/PurrNet/PurrDocs/pull/26?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->