### PR TITLE
Update DDOL documentation for PurrNet

### DIFF
--- a/systems-and-modules/network-identity/dont-destroy-on-load.md
+++ b/systems-and-modules/network-identity/dont-destroy-on-load.md
@@ -10,3 +10,7 @@ private void Awake()
     DontDestroyOnLoad(this);
 }
 ```
+
+Note that PurrNet does not track the DDOL scene by default unless the Network Manager itself is also located there. If your manager lives in a different scene, any Network Identities you move to DDOL will fail to register and will show up as "Not Spawned".
+
+To fix this, locate your NetworkRules asset, go to the scene rules section, and enable `alwaysIncludeDontDestroyOnLoadScene`. This explicitly tells PurrNet to register the DDOL scene so it can discover and spawn your persistent objects correctly.


### PR DESCRIPTION
Added note about PurrNet's handling of DDOL scenes and instructions to enable scene registration.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/PurrNet/codesmith/PurrDocs/pr/28"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784717603&installation_id=129033668&pr_number=28&repository=PurrNet%2FPurrDocs&return_to=https%3A%2F%2Fgithub.com%2FPurrNet%2FPurrDocs%2Fpull%2F28&signature=40db621db0bd90d05105e7db67118485bf053dd8ffe7c075cb60b42765e403d8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated guidance on Don't Destroy On Load scene tracking behavior in relation to Network Manager placement
  * Added configuration instructions to enable persistent Network Identity discovery and spawning

<!-- end of auto-generated comment: release notes by coderabbit.ai -->